### PR TITLE
#1166 Send all data received from the Lex postText API to the onCompl…

### DIFF
--- a/packages/aws-amplify/src/Interactions/Providers/AWSLexProvider.ts
+++ b/packages/aws-amplify/src/Interactions/Providers/AWSLexProvider.ts
@@ -65,11 +65,11 @@ export class AWSLexProvider extends AbstractInteractionsProvider {
                         logger.debug('postText state', data.dialogState);
                         if (data.dialogState === 'ReadyForFulfillment' || data.dialogState === 'Fulfilled') {
                             if (typeof this._botsCompleteCallback[botname] === 'function') {
-                                setTimeout(() => this._botsCompleteCallback[botname](null, { slots: data.slots }), 0);
+                                setTimeout(() => this._botsCompleteCallback[botname](null, data), 0);
                             }
                             
                             if (this._config && typeof this._config[botname].onComplete === 'function') {
-                                setTimeout(() => this._config[botname].onComplete(null, { slots: data.slots }), 0);
+                                setTimeout(() => this._config[botname].onComplete(null, data), 0);
                             }
                         }
                         


### PR DESCRIPTION
…ete callback

Update AWSLexProvider.ts to send all data (and not just data.slots) received from the Lex postText API to the onComplete callback.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
